### PR TITLE
Added support for new video codec tags

### DIFF
--- a/spatialmedia/mpeg/constants.py
+++ b/spatialmedia/mpeg/constants.py
@@ -75,6 +75,11 @@ TAG_AV01 = b"av01"
 TAV_HEV1 = b"hev1"
 TAG_DVH1 = b"dvh1"
 TAG_APCN = b"apcn"
+TAG_APCH = b"apch"
+TAG_APCS = b"apcs"
+TAG_APCO = b"apco"
+TAG_AP4H = b"ap4h"
+TAG_AP4X = b"ap4x"
 
 SOUND_SAMPLE_DESCRIPTIONS = frozenset([
     TAG_NONE,
@@ -100,6 +105,11 @@ VIDEO_SAMPLE_DESCRIPTIONS = frozenset([
     TAV_HEV1,
     TAG_DVH1,
     TAG_APCN,
+    TAG_APCH,
+    TAG_APCS,
+    TAG_APCO,
+    TAG_AP4H,
+    TAG_AP4X
     ])
 
 CONTAINERS_LIST = frozenset([


### PR DESCRIPTION
This pull request adds support for additional video codec tags in the `spatialmedia/mpeg/constants.py` file. These changes expand the set of recognized codec tags to include new Apple ProRes variants.

### Added support for new video codec tags:

* Added the following codec tags to the constants: `TAG_APCH`, `TAG_APCS`, `TAG_APCO`, `TAG_AP4H`, and `TAG_AP4X`. These tags correspond to additional Apple ProRes formats.
* Included the newly added codec tags in the `SOUND_SAMPLE_DESCRIPTIONS` set to ensure they are recognized in relevant contexts.